### PR TITLE
feat: add quasi-static Monte Carlo simulation for error budget analysis

### DIFF
--- a/src/ryd_gate/__init__.py
+++ b/src/ryd_gate/__init__.py
@@ -12,13 +12,15 @@ except ImportError:
     jax_atom_Evolution = None
 
 try:
-    from .ideal_cz import CZGateSimulator
+    from .ideal_cz import CZGateSimulator, MonteCarloResult
 except ImportError:
     CZGateSimulator = None
+    MonteCarloResult = None
 
 __all__ = [
     "jax_atom_Evolution",
     "CZGateSimulator",
+    "MonteCarloResult",
     "blackman_pulse",
     "blackman_pulse_sqrt",
     "blackman_window",


### PR DESCRIPTION
## Summary

Implements quasi-static Monte Carlo simulation capabilities for the `CZGateSimulator` class to reproduce the error budget analysis from the Lukin group's paper (arXiv:2305.03406, Extended Data Fig. 4).

- Add `run_monte_carlo_simulation()` method for statistical averaging over many shots
- Model **Doppler dephasing (T2\*)** via Gaussian-distributed detuning noise
- Model **interaction fluctuations** from finite atomic temperature causing position spread
- Add `get_error_budget()` for computing isolated contributions from each error source
- Add `MonteCarloResult` dataclass for structured results

### Physics Implementation

**Doppler Dephasing (T2\*)**:
- Assumes Gaussian decay profile exp(-(t/T2*)²)
- Detuning noise σ_δ = √2/T2* (default T2* = 3 μs)
- Per-shot random detuning added to Rydberg state diagonal elements

**Position Fluctuations**:
- Position spread σ_pos = √(k_B T / (m ω²)) for thermal harmonic trap
- Typical parameters: T = 10-20 μK, trap_freq = 50 kHz
- Updates V_Ryd = C_6/R^6 with R_new = R_0 + δr_1 - δr_2

### Example Usage

```python
from ryd_gate.ideal_cz import CZGateSimulator

sim = CZGateSimulator(decayflag=False, param_set='our', strategy='TO')
x_opt = [...]  # optimized pulse parameters

# Run Monte Carlo with both error sources
result = sim.run_monte_carlo_simulation(
    x_opt, 
    n_shots=1000,
    T2_star=3e-6,      # 3 μs coherence time
    temperature=15.0,   # 15 μK
    trap_freq=50.0,     # 50 kHz trap frequency
    seed=42
)
print(f"Mean fidelity: {result.mean_fidelity:.6f} ± {result.std_fidelity:.6f}")

# Get full error budget breakdown
budget = sim.get_error_budget(x_opt, n_shots=1000)
print(f"T2* contribution: {budget['T2_star_contribution']:.6f}")
print(f"Position contribution: {budget['position_contribution']:.6f}")
```

## Test plan

- [x] All 50 tests in `test_ideal_cz.py` pass
- [x] New `TestMonteCarloSimulation` class with 16 tests covering:
  - Basic MC runs for TO and AR strategies
  - T2* dephasing only
  - Position fluctuations only
  - Both error sources combined
  - No error sources (reproducibility check)
  - Direct `sigma_pos` input
  - Reproducibility with seed
  - Input validation
  - Helper method unit tests
  - Error budget computation

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)